### PR TITLE
Replace rgl.viewpoint with view3d

### DIFF
--- a/R/plotTopographicMap.R
+++ b/R/plotTopographicMap.R
@@ -366,7 +366,7 @@ if(is.null(ClsColors)){
 ##########################################################################################
  #Aus showUmatrix3d, package Umatrix
    rgl::open3d()
-   rgl::rgl.viewpoint(0, -30,zoom = 0.8)
+   rgl::view3d(0, -30,zoom = 0.8)
   
   if(ShowAxis){
     rgl::material3d(col = "black")


### PR DESCRIPTION
Some upcoming changes to the rgl package will require changes to your package.  I will be deprecating a number of rgl.* function calls. You can read about the issues here:

      https://dmurdoch.github.io/rgl/articles/deprecation.html

I have made the required change to GeneralizedUmatrix in the attached patch. These changes should work with both old and new rgl versions.

Duncan Murdoch