### PR TITLE
Add RcppParallel cxxflags to makevars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -18,5 +18,6 @@
 #PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 
 #RcppParallel
+PKG_CXXFLAGS += $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::CxxFlags()")
 PKG_LIBS += $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::RcppParallelLibs()")
 CXX_STD = CXX11

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -22,5 +22,6 @@
 #RcppParallel
 CXX_STD = CXX11
 PKG_CXXFLAGS += -DRCPP_PARALLEL_USE_TBB=1
+PKG_CXXFLAGS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "RcppParallel::CxxFlags()")
 PKG_LIBS += $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" \
               -e "RcppParallel::RcppParallelLibs()")


### PR DESCRIPTION
This PR updates your Makevars to add RcppParallel's CXXFLAGS, which will be needed for compatibility with Windows ARM64